### PR TITLE
Fix release_key handling when Num Lock is on

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -471,7 +471,7 @@ function _M.switch(dir, mod_key1, release_key, mod_key2, key_switch)
 		function (mod, key, event)
 			-- Stop alt-tabbing when the alt-key is released
 			if gears.table.hasitem(mod, mod_key1) then
-				if (#mod == 1 and key == release_key) or key == "Escape" and event == "release" then
+				if (key == release_key or key == "Escape") and event == "release" then
 					if _M.preview_wbox.visible == true then
 						_M.preview_wbox.visible = false
 						_M.preview_live_timer:stop()


### PR DESCRIPTION
Num Lock counts as a modifier key. Since at the time of running the
handler mod_key1 is being pressed, #mod equals 2 in such case.

This commit removes completely `#mod == 1` condition from the handler. I
am not sure why was it added in the first place, but it does not make
much sense from my point of view. Perhaps @berlam will know more?

The plugin seems to work flawlessly after this change.

Resolves berlam/awesome-switcher#9